### PR TITLE
Language And Tools: update GitHub logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <img align="left" alt="JavaScript" width="26px" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/javascript/javascript.png" />
 <img align="left" alt="JavaScript" width="26px" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/typescript/typescript.png" />
 <img align="left" alt="Git" width="26px" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/git/git.png" />
-<img align="left" alt="GitHub" width="26px" src="https://raw.githubusercontent.com/github/explore/78df643247d429f6cc873026c0622819ad797942/topics/github/github.png" />
+<img align="left" alt="GitHub" width="26px" src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" />
 <img align="left" alt="Terminal" width="26px" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/terminal/terminal.png" />
 
 <br />


### PR DESCRIPTION
## Problem : - 
the old GitHub logo under `language and tools` section of readme was not visible in GitHub new dark mode

- sample before fix :- 
<img width="225" alt="Screenshot 2020-12-24 at 10 02 32 AM" src="https://user-images.githubusercontent.com/54987647/103060922-a7c22f00-45cf-11eb-96d7-6c57900f6bc3.png">

## fix : -
changed the image to a one with white background so that it is visible in both dark and light mode

- sample after fix: -
<img width="202" alt="Screenshot 2020-12-24 at 10 02 37 AM" src="https://user-images.githubusercontent.com/54987647/103060995-ddffae80-45cf-11eb-9eed-4cc12cf48c81.png">


